### PR TITLE
Update documentation, remove links for older repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
-### Android App + NLTK
-https://github.com/pingu-73/megathon-pentagon-frontend-nltk
+### Android App and Website
+
+[Here](frontend/app/PsycheTest) is the quiz app developed in Kotlin.
+
+[Here](frontend/webiste) is the web version of the app with same functionality.
+
+
+
+### NLTK
+
+This is implementation of the training model using Python-nltk
+[Link](backend/mynltk)
 
 # Overview
 


### PR DESCRIPTION
## Current State

- There are no links to the app or the website
- The link for nltk in the older repo `megathon-pentagon`, is outdated with less functionality.

## Proposed Changes

- Add links for website and the app.
- Add links for the nltk model