### PR TITLE
fix link typo in website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Here](frontend/app/PsycheTest) is the quiz app developed in Kotlin.
 
-[Here](frontend/webiste) is the web version of the app with same functionality.
+[Here](frontend/website) is the web version of the app with same functionality.
 
 
 


### PR DESCRIPTION
# Current State
- the link in the readme for website reads 'webiste'.
# Changes
- change it to 'website'